### PR TITLE
Rename and add a script to update version to match OpenSearch Dashboards

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 ### Check List
 - [ ] New locale: New [issue](https://github.com/opensearch-project/OpenSearch-Dashboards/issues) has been opened in OpenSearch Dashboards for support.
-- [ ] New locale: [DEVELOPER_GUIDE](https://github.com/opensearch-project/i18n-plugin/blob/main/DEVELOPER_GUIDE.md#new-locale:~:text=are%20correctly%20translated.-,New%20locale,-Currently%2C%20we%20support) has been updated.
+- [ ] New locale: [DEVELOPER_GUIDE](https://github.com/opensearch-project/dashboards-i18n/blob/main/DEVELOPER_GUIDE.md#new-locale:~:text=are%20correctly%20translated.-,New%20locale,-Currently%2C%20we%20support) has been updated.
 - [ ] Commits are signed per the DCO using --signoff
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/.i18nrc.json
+++ b/.i18nrc.json
@@ -1,7 +1,7 @@
 {
-  "prefix": "i18nPlugin",
+  "prefix": "i18nDashboards",
   "paths": {
-    "i18nPlugin": "."
+    "i18nDashboards": "."
   },
   "translations": []
 }

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -8,7 +8,7 @@
 
 ## Developer guide
 
-We're glad you're here. i18n-plugin is a community driven plugin for localization. To use it, here's what you need to do.
+We're glad you're here. dashboards-i18n is a community driven plugin for localization. To use it, here's what you need to do.
 
 ### Forking and Cloning
 
@@ -17,23 +17,35 @@ Fork this repository on GitHub, and clone locally with `git clone`.
 ### Environment Setup
 
 1. Download OpenSearch. You could clone the [OpenSearch repo](https://github.com/opensearch-project/OpenSearch.git), use [docker](https://opensearch.org/docs/latest/opensearch/install/docker/) or [artifact](https://opensearch.org/docs/latest/opensearch/install/tar/). Make sure the version matches the OpenSearch Dashboards version.
+
 2. Setup the environment to run OpenSearch Dashboards. You will need to install [node.js](https://nodejs.org/en/), [nvm](https://github.com/nvm-sh/nvm/blob/master/README.md), and [yarn](https://yarnpkg.com/) in your environment to properly pull down dependencies to build and bootstrap.
+
 3. Download the OpenSearch-Dashboards source code.
 
    See the [OpenSearch Dashboards developer guide](https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md) for more instructions on setting up your development environment.
 
 4. Change your node version to the version specified in `.node-version` inside the OpenSearch-Dashboards root directory.
-5. cd into the `plugins` directory of the OpenSearch-Dashboards source code directory. Clone [i18n-plugin](https://github.com/opensearch-project/i18n-plugin.git) into the `plugins` directory. Ultimately, your directory structure should look like this:
+
+5. cd into the `plugins` directory of the OpenSearch-Dashboards source code directory. Clone [dashboards-i18n](https://github.com/opensearch-project/dashboards-i18n.git) into the `plugins` directory. Ultimately, your directory structure should look like this:
 
 ```md
 .
 ├── OpenSearch-Dashboards
 │   └── plugins
-│       └── i18n-plugin
+│       └── dashboards-i18n
 ```
-6. Config localization in i18n-plugin. Add a locale json file in `translations` directory of the i18n-plugin. Specify the path in `.i18nrc.json`. For example, if the locale json file you added is called `zh-CN.json`, the path should be `"translations": ["translations/zh-CN.json"]`.
-7. Config localization in OpenSearch Dashboards. cd into the `config` directory of the OpenSearch-Dashboards source code directory. Add `i18n.locale: "{your locale}"` in `opensearch_dashboards.yml` file.
-8. Run `yarn osd bootstrap` under `Opensearch-Dashboards`.
+
+6. Make sure the version of dashboards-i18n plugin in the `opensearch_dashboards.json` file matches the version of OpenSearch Dashboards. If the version needs to be updated, you can use the provided script to automatically update the `opensearchDashboardsVersion` in the `opensearch_dashboards.json` file. To update the version, run the following command in the `dashboards-i18n` directory:
+
+```bash
+yarn update-version
+```
+
+7. Config localization in dashboards-i18n. Add a locale json file in `translations` directory of the dashboards-i18n. Specify the path in `.i18nrc.json`. For example, if the locale json file you added is called `zh-CN.json`, the path should be `"translations": ["translations/zh-CN.json"]`.
+
+8. Config localization in OpenSearch Dashboards. cd into the `config` directory of the OpenSearch-Dashboards source code directory. Add `i18n.locale: "{your locale}"` in `opensearch_dashboards.yml` file.
+
+9. Run `yarn osd bootstrap` under `Opensearch-Dashboards`.
 
 ### Run
 
@@ -44,9 +56,9 @@ Fork this repository on GitHub, and clone locally with `git clone`.
   - You must have OpenSearch running.
 
 ### Example
-  
+
 1. Setup environment. Please refer to [Environment Setup](#environment-setup).
-2. Config localization in i18n-plugin. Add the following example `zh-CN.json` file in `translations` directory. In `.i18nrc.json`, add the path `"translations": ["translations/zh-CN.json"`. 
+2. Config localization in dashboards-i18n. Add the following example `zh-CN.json` file in `translations` directory. In `.i18nrc.json`, add the path `"translations": ["translations/zh-CN.json"`.
 
 
 ```json
@@ -153,7 +165,7 @@ Fork this repository on GitHub, and clone locally with `git clone`.
 
 ### New locale
 
-Currently, we support en/en-US (English), es/es-LA (Spanish), fr/fr-FR (French), de/de-DE (German), ja/ja-JP (Japanese), ko/ko-KR (Korean), zh/zh-CN (Chinese). If your locale is not in it, please open an issue in OpenSearch Dashboards.
+Currently, we support en/en-US (English), es/es-LA (Spanish), fr/fr-FR (French), de/de-DE (German), ja/ja-JP (Japanese), ko/ko-KR (Korean), ru/ru-RU (Russian), zh/zh-CN (Chinese). If your locale is not in it, please open an issue in OpenSearch Dashboards.
 
 ### Contribute
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 <img src="https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_default.svg" height="64px"/>
 
-- [i18n-plugin](#i18n-plugin)
+- [dashboards-i18n](#dashboards-i18n)
 - [Contributing](#contributing)
 - [Code of Conduct](#code-of-conduct)
 - [Security](#security)
 - [License](#license)
 - [Copyright](#copyright)
 
-# i18n-plugin
+# dashboards-i18n
 
-The i18n-plugin lets you build localized OpenSearch Dashboards platform and plugins.
+The dashboards-i18n lets you build localized OpenSearch Dashboards platform and plugins.
 
 ## Contributing
 

--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -1,5 +1,5 @@
-** i18n-plugin; version 1.0 --
-https://github.com/opensearch-project/i18n-plugin/tree/main
+** dashboards-i18n; version 1.0 --
+https://github.com/opensearch-project/dashboards-i18n/tree/main
 
 Apache License
 

--- a/common/index.ts
+++ b/common/index.ts
@@ -3,5 +3,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export const PLUGIN_ID = 'i18nPlugin';
-export const PLUGIN_NAME = 'i18n-plugin';
+export const PLUGIN_ID = 'i18nDashboards';
+export const PLUGIN_NAME = 'dashboards-i18n';

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,5 +1,5 @@
 {
-  "id": "i18nPlugin",
+  "id": "i18nDashboards",
   "version": "2.1.0.0",
   "opensearchDashboardsVersion": "2.1.0",
   "server": true,

--- a/package.json
+++ b/package.json
@@ -1,21 +1,22 @@
 {
-  "name": "i18n-plugin",
+  "name": "i18n-dashboards",
   "version": "2.1.0.0",
   "description": "plugin for opensearch-dashboards translation",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "node ../../scripts/eslint ."
+    "lint": "node ../../scripts/eslint .",
+    "update-version": "node scripts/update_opensearch_dashboards_version.js"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/opensearch-project/i18n-plugin.git"
+    "url": "git+https://github.com/opensearch-project/dashboards-i18n.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/opensearch-project/i18n-plugin/issues"
+    "url": "https://github.com/opensearch-project/dashboards-i18n/issues"
   },
-  "homepage": "https://github.com/opensearch-project/i18n-plugin#readme"
+  "homepage": "https://github.com/opensearch-project/dashboards-i18n#readme"
 }

--- a/scripts/update_opensearch_dashboards_version.js
+++ b/scripts/update_opensearch_dashboards_version.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+
+const packageJson = require('../../../package.json');
+console.log(packageJson.version);
+const opensearchDashboardsJsonPath = path.join(__dirname, '..', 'opensearch_dashboards.json');
+
+// Read the existing opensearch_dashboards.json file
+const opensearchDashboardsJson = JSON.parse(fs.readFileSync(opensearchDashboardsJsonPath, 'utf8'));
+
+// Update the opensearchDashboardsVersion value
+opensearchDashboardsJson.opensearchDashboardsVersion = packageJson.version;
+
+// Write the updated JSON back to the file
+fs.writeFileSync(opensearchDashboardsJsonPath, JSON.stringify(opensearchDashboardsJson, null, 2));

--- a/server/index.ts
+++ b/server/index.ts
@@ -4,13 +4,13 @@
  */
 
 import { PluginInitializerContext } from '../../../src/core/server';
-import { I18nPluginPlugin } from './plugin';
+import { I18nDashboardsPlugin } from './plugin';
 
 // This exports static code and TypeScript types,
 // as well as, OpenSearch Dashboards Platform `plugin()` initializer.
 
 export function plugin(initializerContext: PluginInitializerContext) {
-  return new I18nPluginPlugin(initializerContext);
+  return new I18nDashboardsPlugin(initializerContext);
 }
 
-export { I18nPluginPluginSetup, I18nPluginPluginStart } from './types';
+export { I18nDashboardsPluginSetup, I18nDashboardsPluginStart } from './types';

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -11,10 +11,10 @@ import {
   Logger,
 } from '../../../src/core/server';
 
-import { I18nPluginPluginSetup, I18nPluginPluginStart } from './types';
+import { I18nDashboardsPluginSetup, I18nDashboardsPluginStart } from './types';
 import { defineRoutes } from './routes';
 
-export class I18nPluginPlugin implements Plugin<I18nPluginPluginSetup, I18nPluginPluginStart> {
+export class I18nDashboardsPlugin implements Plugin<I18nDashboardsPluginSetup, I18nDashboardsPluginStart> {
   private readonly logger: Logger;
 
   constructor(initializerContext: PluginInitializerContext) {
@@ -22,7 +22,7 @@ export class I18nPluginPlugin implements Plugin<I18nPluginPluginSetup, I18nPlugi
   }
 
   public setup(core: CoreSetup) {
-    this.logger.debug('i18n-plugin: Setup');
+    this.logger.debug('dashboards-i18n: Setup');
     const router = core.http.createRouter();
 
     // Register server side APIs
@@ -32,7 +32,7 @@ export class I18nPluginPlugin implements Plugin<I18nPluginPluginSetup, I18nPlugi
   }
 
   public start(core: CoreStart) {
-    this.logger.debug('i18n-plugin: Started');
+    this.logger.debug('dashboards-i18n: Started');
     return {};
   }
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -8,7 +8,7 @@ import { IRouter } from '../../../../src/core/server';
 export function defineRoutes(router: IRouter) {
   router.get(
     {
-      path: '/api/i18n_plugin/example',
+      path: '/api/dashboards_i18n/example',
       validate: false,
     },
     async (context, request, response) => {

--- a/server/types.ts
+++ b/server/types.ts
@@ -4,6 +4,6 @@
  */
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface I18nPluginPluginSetup {}
+export interface I18nDashboardsPluginSetup {}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface I18nPluginPluginStart {}
+export interface I18nDashboardsPluginStart {}


### PR DESCRIPTION
### Description
* Rename due to plugin naming convention
* I18n is a self maintained repo and won't have a lot of updates except translation files. Currently, OpenSearch Dashboards requests all plugins to match its version. Therefore, we add a script to update version in opensearch_dashboards.json automatically.

### Partially Resolve
https://github.com/opensearch-project/opensearch-plugins/issues/174

### Test
Did a manual test to run the script in OpenSearch Dashboards 3.0.0 and use sample data from DEVELOPER_GUIDE to run:
<img width="1699" alt="Screenshot 2023-04-07 at 12 30 18" src="https://user-images.githubusercontent.com/79961084/230674376-5ae46603-1a43-4fb7-b6f4-6f1497524564.png">


### Check List
- [ ] New locale: New [issue](https://github.com/opensearch-project/OpenSearch-Dashboards/issues) has been opened in OpenSearch Dashboards for support.
- [x] New locale: [DEVELOPER_GUIDE](https://github.com/opensearch-project/i18n-plugin/blob/main/DEVELOPER_GUIDE.md#new-locale:~:text=are%20correctly%20translated.-,New%20locale,-Currently%2C%20we%20support) has been updated.
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).